### PR TITLE
Fix wrong command on homepage

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -23,7 +23,7 @@ getting_started_button: "<a href='/documentation/getting-started' class='cta'>St
 
   %p All you need to get started is install the library with :
   :markdown
-    `go install -u github.com/hybridgroup/gobot`.
+    `go get -u github.com/hybridgroup/gobot`.
 
   %h2.homepage  Gobot with Sphero
   :markdown


### PR DESCRIPTION
There is an error on homepage. You indicate to run:

```
go install -u github.com/hybridgroup/gobot
```

But it should be:

```
go get -u github.com/hybridgroup/gobot
```

As indicated in the [Getting started doc](http://gobot.io/documentation/getting-started/).

Fixes https://github.com/hybridgroup/gobot/issues/117#issuecomment-57947138
