### PR TITLE
Firmata Install Path

### DIFF
--- a/source/documentation/platforms/arduino.html.haml
+++ b/source/documentation/platforms/arduino.html.haml
@@ -40,7 +40,7 @@ subnavjs: true
   %p Installing Gobot with Arduino support is pretty easy.
   :markdown
         :::bash
-        go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/platforms/firmata
+        go get github.com/hybridgroup/gobot && go install github.com/hybridgroup/gobot/platforms/firmata
 
   %p 
     %b Note:


### PR DESCRIPTION
Update Firmata platform path to match the Gobot install path on the Arduino page.
