### PR TITLE
Update the getting started to include the package main

### DIFF
--- a/source/documentation/getting-started/index.html.haml
+++ b/source/documentation/getting-started/index.html.haml
@@ -40,6 +40,8 @@ layout: documentation
     every one second. Take note that your arduino may be on a different port number.
   :markdown
         :::go
+        package main
+        
         import (
                 "time"
 


### PR DESCRIPTION
This is a minor thing, but tripped me up briefly with the getting started guide. I tossed the `package main` line at the top of the script so this can run with a copy paste into a file if need be.
