### PR TITLE
Fix typo on go get (missing '.')

### DIFF
--- a/source/documentation/getting-started/index.html.haml
+++ b/source/documentation/getting-started/index.html.haml
@@ -22,7 +22,7 @@ layout: documentation
   %h2 Install Gobot
   :markdown
     Download Gobot and it's required dependencies with:   
-      `go get -d -u github.com/hybridgroup/gobot/..`
+      `go get -d -u github.com/hybridgroup/gobot/...`
 
 
   %section


### PR DESCRIPTION
needs

go get -d -u github.com/hybridgroup/gobot/...

instead of 

go get -d -u github.com/hybridgroup/gobot/..
