### PR TITLE
Add a feed to the blog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem 'rack-google-analytics'
 gem "middleman-livereload", "~> 3.1.0"
 
 gem 'git'
+gem 'builder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     bourbon (4.1.1)
       sass (~> 3.3)
       thor
+    builder (3.2.2)
     chunky_png (1.3.3)
     coderay (1.1.0)
     coffee-script (2.2.0)
@@ -138,6 +139,7 @@ PLATFORMS
 
 DEPENDENCIES
   bourbon
+  builder
   coderay
   git
   middleman (= 3.2.2)

--- a/config.rb
+++ b/config.rb
@@ -16,6 +16,8 @@ activate :blog do |blog|
   blog.tag_template = "blog/tag.html"
 end
 
+page "/blog/feed.xml", layout: false
+
 activate :directory_indexes
 activate :neat
 activate :livereload
@@ -33,5 +35,9 @@ helpers do
 
     properties
   end
-end
 
+  def article_author(article)
+    article.data.author || "Staff"
+  end
+
+end

--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -1,0 +1,23 @@
+xml.instruct!
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
+  site_url = "http://gobot.io/"
+  xml.title "Blog - Gobot"
+  xml.subtitle "Golang framework for robotics, physical computing, and the Internet of Things"
+  xml.id URI.join(site_url, blog.options.prefix.to_s + "/")
+  xml.link "href" => URI.join(site_url, blog.options.prefix.to_s + "/")
+  xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
+  xml.updated(blog.articles.first.date.to_time.iso8601) unless blog.articles.empty?
+
+  blog.articles[0..20].each do |article|
+    xml.entry do
+      xml.title article.title
+      xml.link "rel" => "alternate", "href" => URI.join(site_url, article.url)
+      xml.id URI.join(site_url, article.url)
+      xml.published article.date.to_time.iso8601
+      xml.updated File.mtime(article.source_file).iso8601
+      xml.author { xml.name article_author(article) }
+      # xml.summary article.summary, "type" => "html"
+      xml.content article.body, "type" => "html"
+    end
+  end
+end

--- a/source/layouts/_contents-blog.html.haml
+++ b/source/layouts/_contents-blog.html.haml
@@ -8,3 +8,5 @@
     = link_to image_tag("elements/twitter.png"), "https://twitter.com/gobotio"
     = link_to image_tag("elements/github.png"), "https://github.com/hybridgroup/gobot"
 
+-content_for :head do
+  %link{href: '/blog/feed.xml', rel: 'alternate', type: 'application/atom+xml', title: "Atom Feed" }/

--- a/source/layouts/hybridpages/_head.html.haml
+++ b/source/layouts/hybridpages/_head.html.haml
@@ -9,6 +9,7 @@
 %script{:src => "//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"}
 %script{:src => "/javascripts/vendor/angular.min.js"}
 %script{:src => "/javascripts/app.js"}
+= yield_content :head
 
 - if current_page.data.subnavjs == true
   %script{:src => "/javascripts/subnav.js"}


### PR DESCRIPTION
This change adds an Atom feed to the blog. The feed itself and the config are roughly based off the templates in the [middleman 3.x tree](https://github.com/middleman/middleman-blog/blob/v3-stable/lib/middleman-blog/template/source/feed.xml.builder)
- add builder to the Gemfile
- add the feed.xml.builder template to blog/
- instruct middleman to render feed without a layout in config.rb
- add an author helper to config.rb. Defaults to “Staff” if no author is specified.
- add feed autodiscovery to blog templates
- add `yield` content block to the _head template (note the preceding whitespace here, it triggers a rebuild of some of the other pages)
- add the autodiscovery link to the contents-blog partial
