### PR TITLE
Fix Digispark API Reference to only existing docs on godoc

### DIFF
--- a/source/documentation/platforms/digispark.html.haml
+++ b/source/documentation/platforms/digispark.html.haml
@@ -5,7 +5,7 @@ page_title: Platforms
 page_subtitle: Gobot has a extensible system for connecting to hardware devices. The following robotics and physical computing platforms are currently supported.
 page_title_docs: Digispark
 page_subtitle_docs: "<a href='https://github.com/hybridgroup/gobot' target='_blank' class='repository'>Repository</a> <a class+'issues' target='_blank' href='https://github.com/hybridgroup/gobot/issues'>Issues</a>"
-api_reference: <a href='http://godoc.org/gobot.io/x/gobot/platforms/digispark#DigisparkAdaptor' target='blank' class='api-link'>API Reference</a>
+api_reference: <a href='https://godoc.org/github.com/edmontongo/gobot/platforms/digispark' target='blank' class='api-link'>API Reference</a>
 page_title_show: true
 layout: documentation
 subnav_platform: true


### PR DESCRIPTION
I changed the link to the only docs I could find. You likely want to docs that come from Gobot itself, but those don't seem to exist at this point, so this is the next best alternative. 

This should resolve: https://github.com/hybridgroup/gobot/issues/383

