### PR TITLE
New link to VICE Motherboard Blog post

### DIFF
--- a/source/news/index.html.haml
+++ b/source/news/index.html.haml
@@ -17,7 +17,7 @@ page_title_show: true
     = link_to "Internet of Anything: Simple Tools Make It Possible for Anyone to Hack Robots - Wired features Gobot", "http://www.wired.com/2015/04/internet-anything-time-everyone-able-hack-robots/", target:"_blank", class: "external-link"
 
   %p
-    = link_to "Opening Up the World of Robotics: 'The Internet Of Toys' - Gobot in VICE Motherboard", "http://motherboard.vice.com/blog/opening-up-the-world-of-robotics", target:"_blank", class: "external-link"
+    = link_to "Opening Up the World of Robotics: 'The Internet Of Toys' - Gobot in VICE Motherboard", "https://motherboard.vice.com/en_us/article/opening-up-the-world-of-robotics", target:"_blank", class: "external-link"
 
   %p
     = link_to "Industry Spotlight: Internet of Things: Closing the gap between customers, business - Gobot in SDTimes", "http://sdtimes.com/closing-the-gap-between-customers-business/", target:"_blank", class: "external-link"


### PR DESCRIPTION
Old link (http://motherboard.vice.com/blog/opening-up-the-world-of-robotics) led to a 404 (at least from Germany). Google revealed that the article link might have changed.