### PR TITLE
Add hyperlink for mqtt

### DIFF
--- a/source/documentation/platforms/partials/mqtt.html.haml
+++ b/source/documentation/platforms/partials/mqtt.html.haml
@@ -4,8 +4,7 @@
 
     This repository contains the Gobot adaptor/driver to connect to MQTT servers. It uses the Paho MQTT Golang client package (https://eclipse.org/paho/) created and maintained by the Eclipse Foundation (https://github.com/eclipse) thank you!
 
-    For more info about the MQTT machine to machine messaging standard, go to http://mqtt.org/
-
+    For more info about the MQTT machine to machine messaging standard, go to [http://mqtt.org/](http://mqtt.org/).
 
   = current_page.data.api_reference
 .clear


### PR DESCRIPTION
Add hyperlink for mqtt in order to match other platforms.