### PR TITLE
Fixed Firmata links

### DIFF
--- a/source/documentation/platforms/partials/esp8266.html.haml
+++ b/source/documentation/platforms/partials/esp8266.html.haml
@@ -2,7 +2,7 @@
   :markdown
 
 
-    Gobot provides an adaptor for the ESP8266 as well as Arduino-compatible microcontrollers that support the [Firmata](http://firmata.org/wiki/Main_Page) protocol used with a WiFi adaptor.
+    Gobot provides an adaptor for the ESP8266 as well as Arduino-compatible microcontrollers that support the [Firmata](https://github.com/firmata/protocol) protocol used with a WiFi adaptor.
 
     For more info about the ESP8266 platform go to [http://espressif.com/products/hardware/esp8266ex/overview/](http://espressif.com/products/hardware/esp8266ex/overview/).
 

--- a/source/documentation/platforms/partials/firmata.html.haml
+++ b/source/documentation/platforms/partials/firmata.html.haml
@@ -2,7 +2,7 @@
   :markdown
     Arduino is an open-source electronics prototyping platform based on flexible, easy-to-use hardware and software. It's intended for artists, designers, hobbyists and anyone interested in creating interactive objects or environments.
 
-    This package provides the adaptor for microcontrollers such as Arduino that support the [Firmata](http://firmata.org/wiki/Main_Page) protocol
+    This package provides the adaptor for microcontrollers such as Arduino that support the [Firmata](https://github.com/firmata/protocol) protocol
 
     You can connect to the microcontroller using either a serial connection, or a TCP connection to a WiFi-connected microcontroller such as the ESP8266.
 


### PR DESCRIPTION
The previously-linked Firmata homepage is no longer available. I found the official repo on GitHub which seems to be as good of a place to link to as any.