### PR TITLE
Update import and fix undeclared name error in code example.

### DIFF
--- a/source/documentation/core/api.html.haml
+++ b/source/documentation/core/api.html.haml
@@ -52,8 +52,8 @@ active_menu_docs: true
           "html"
           "net/http"
 
-          "github.com/hybridgroup/gobot"
-          "github.com/hybridgroup/gobot/api"
+          "gobot.io/x/gobot"
+          "gobot.io/x/gobot/api"
         )
 
         func main() {
@@ -66,16 +66,16 @@ active_menu_docs: true
           a.Debug()
           a.Start()
 
-          gbot.AddCommand("custom_gobot_command",
+          mbot.AddCommand("custom_gobot_command",
             func(params map[string]interface{}) interface{} {
               return "This command is attached to the mcp!"
             })
 
-          hello := gbot.AddRobot(gobot.NewRobot("hello"))
+          hello := mbot.AddRobot(gobot.NewRobot("hello"))
 
           hello.AddCommand("hi_there", func(params map[string]interface{}) interface{} {
             return fmt.Sprintf("This command is attached to the robot %v", hello.Name)
           })
 
-          gbot.Start()
+          mbot.Start()
         }


### PR DESCRIPTION
Imports in code example were outdated and there was a typo in Gobot Master declaration causing 'undeclared name' error on compiling.